### PR TITLE
口パクのしきい値設定を追加

### DIFF
--- a/YukkuLips.py
+++ b/YukkuLips.py
@@ -21,7 +21,7 @@ import wx.adv as ADV
 
 
 class YKLAppWindow(wx.Frame):
-    def __init__(self, parent, idx, title, size=(800, 670)):
+    def __init__(self, parent, idx, title, size=(800, 675)):
         super().__init__(parent, idx, title, size=size)
         self.context = YKLContext()
         self.image_disp = None
@@ -49,7 +49,7 @@ class YKLAppWindow(wx.Frame):
         hbox.Add(self.image_disp, proportion=1, flag=wx.EXPAND)
         hbox.Add(self.still_set, proportion=0, flag=wx.EXPAND)
 
-        self.av_set = AVSetPanel(panel, wx.ID_ANY, self.context, size=(800, 150))
+        self.av_set = AVSetPanel(panel, wx.ID_ANY, self.context, size=(800, 155))
 
         vbox.Add(hbox, proportion=1, flag=wx.EXPAND)
         vbox.Add(self.av_set, proportion=0, flag=wx.EXPAND)
@@ -165,6 +165,7 @@ class YKLAppWindow(wx.Frame):
         builder.set_voice_interval(self.context.voice_interval)
         builder.set_blink_interval(self.context.blink_interval)
         builder.set_blink_type(list(self.context.blink_types).index(self.context.blink_type))
+        builder.set_mouth_threshold(self.context.mouth_threshold)
         builder.set_movie_size(self.context.movie_size)
         builder.set_sozai_pos(self.context.sozai_pos)
         builder.set_sozai_scale(self.context.sozai_scale)
@@ -183,7 +184,7 @@ class YKLAppWindow(wx.Frame):
             pathname = fileDialog.GetPath()
         project_backup = copy(self.context.project)
         if not self.context.project.open(pathname):
-            wx.MessageBox("サポートされていないプロジェクトバージョンです", "エラー", wx.ICON_QUESTION | wx.OK, None)
+            wx.MessageBox("現在サポートされていないプロジェクトバージョンです", "エラー", wx.ICON_QUESTION | wx.OK, None)
             return
         paths = [Path(self.context.project.contents["Sozai Directory"]),
                  Path(self.context.project.contents["Audio Directory"])]

--- a/ykl_core/media_utility/audio_tool.py
+++ b/ykl_core/media_utility/audio_tool.py
@@ -13,11 +13,11 @@ import wx
 import subprocess
 
 
-def get_sound_map(sound_file, imgs_num):
+def get_sound_map(sound_file, imgs_num, threshold_ratio=1.0):
     data, fs = sf.read(sound_file, always_2d=True)
     data = [d[0] ** 2 for d in data]
     buf = []
-    thresholds = [(1 / imgs_num * (i + 1)) ** 2 / 2 for i in range(imgs_num)]
+    thresholds = [(1 / imgs_num * (i + 1)) ** 2 / 2 * threshold_ratio for i in range(imgs_num)]
     work_num = int(len(data)/1470)
     progress_dialog = wx.ProgressDialog(
         title="動画出力",

--- a/ykl_core/ykl_context.py
+++ b/ykl_core/ykl_context.py
@@ -62,6 +62,7 @@ class YKLContext:
         self.blink_interval = 5.0
         self.blink_types = ("定期往復型", "登場退場型")
         self.blink_type = self.blink_types[0]
+        self.mouth_threshold = 1.0
         self.movie_sizes = (MovieSize(name="720p", size_tuple=(1280, 720)),
                             MovieSize(name="1080p", size_tuple=(1920, 1080)))
         self.movie_size = self.movie_sizes[0]
@@ -228,7 +229,7 @@ class YKLContext:
             total_sound = join_sound_files(*sound_files, interval=self.voice_interval, audio_cache=self.audio_path)
             if total_sound is None:
                 return
-            sound_level_seq = get_sound_map(total_sound, len(mouth_paths))
+            sound_level_seq = get_sound_map(total_sound, len(mouth_paths), threshold_ratio=self.mouth_threshold)
         else:
             sound_level_seq = []
             if self.silent_interval > 2:
@@ -357,6 +358,7 @@ class YKLContext:
         self.voice_interval = self.project.contents["Voice Interval"]
         self.blink_interval = self.project.contents["Blink Interval"]
         self.blink_type = self.blink_types[self.project.contents["Blink Type"]]
+        self.mouth_threshold = self.project.contents["Mouth Threshold"]
         self.movie_size = self.movie_sizes[
             [movie_size.name for movie_size in self.movie_sizes].index(self.project.contents["Movie Size"])]
         self.sozai_pos = (self.project.contents["Sozai Position"]["x"], self.project.contents["Sozai Position"]["y"])

--- a/ykl_core/ykl_project.py
+++ b/ykl_core/ykl_project.py
@@ -55,6 +55,9 @@ class YKLProjectBuilder:
     def set_blink_type(self, blink_type):
         self.project.contents["Blink Type"] = blink_type
 
+    def set_mouth_threshold(self, mouth_threshold):
+        self.project.contents["Mouth Threshold"] = mouth_threshold
+
     def set_movie_size(self, movie_size):
         self.project.contents["Movie Size"] = movie_size.name
 
@@ -79,7 +82,7 @@ class YKLProject:
     def __init__(self):
         image_dic: Dict[str, List[str]] = {}
         self.contents = {
-            "Project Version": 0.1,
+            "Project Version": 0.2,
             "Project Name": "",
             "Sozai Directory": "",
             "Current Images": image_dic,
@@ -92,11 +95,13 @@ class YKLProject:
             "Voice Interval": 0.8,
             "Blink Interval": 15.0,
             "Blink Type": 0,
+            "Mouth Threshold": 1.0,
             "Movie Size": "720p",
             "Sozai Position": {"x": 0, "y": 0},
             "Sozai Scale": 1.0,
             "BG Reference": None,
         }
+        self.supported_proj_version = (0.2, )
         self.location = str(Path.home())
 
     def save_as(self, file_path):
@@ -111,7 +116,7 @@ class YKLProject:
     def open(self, file_path):
         with open(file_path, 'r') as f:
             self.contents = json.load(f)
-        if self.contents["Project Version"] != 0.1:
+        if self.contents["Project Version"] not in self.supported_proj_version:
             return False
         self.location = file_path
         return True

--- a/ykl_ui/av_set_panel.py
+++ b/ykl_ui/av_set_panel.py
@@ -23,6 +23,7 @@ class AVSetPanel(wx.Panel):
         self.interval_spin = None
         self.blink_choice = None
         self.blink_spin = None
+        self.threshold_spin = None
         self.proj_name_text = None
         self.create_widgets()
 
@@ -84,10 +85,20 @@ class AVSetPanel(wx.Panel):
         blink_box.Add(blink_title, flag=wx.LEFT, border=20)
         blink_box.Add(self.blink_spin)
         blink_box.Add(blink_lbl)
+        threshold_box = wx.BoxSizer(wx.HORIZONTAL)
+        threshold_lbl = wx.StaticText(self, wx.ID_ANY, label="口パクのしきい値：")
+        self.threshold_spin = wx.SpinCtrlDouble(self, wx.ID_ANY, size=(50, 20))
+        self.threshold_spin.SetValue(self.context.mouth_threshold)
+        self.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_spin_ctrl, id=self.threshold_spin.GetId())
+        bai_lbl = wx.StaticText(self, wx.ID_ANY, label="倍")
+        threshold_box.Add(threshold_lbl, flag=wx.LEFT, border=20)
+        threshold_box.Add(self.threshold_spin)
+        threshold_box.Add(bai_lbl)
 
         setting_box.Add(anime_set_lbl, flag=wx.ALL, border=5)
         setting_box.Add(blink_type_box, flag=wx.BOTTOM, border=5)
-        setting_box.Add(blink_box)
+        setting_box.Add(blink_box, flag=wx.BOTTOM, border=5)
+        setting_box.Add(threshold_box)
 
         project_box = wx.BoxSizer(wx.VERTICAL)
 
@@ -148,6 +159,8 @@ class AVSetPanel(wx.Panel):
             self.context.blink_interval = event.GetValue()
         elif event.GetId() == self.silent_second.GetId():
             self.context.silent_interval = event.GetValue()
+        elif event.GetId() == self.threshold_spin.GetId():
+            self.context.mouth_threshold = event.GetValue()
         self.GetParent().GetParent().disp_unsaved()
 
     def setting_audio_from_context(self):
@@ -164,6 +177,7 @@ class AVSetPanel(wx.Panel):
     def setting_anime_from_context(self):
         self.blink_choice.SetSelection(self.context.blink_types.index(self.context.blink_type))
         self.blink_spin.SetValue(self.context.blink_interval)
+        self.threshold_spin.SetValue(self.context.mouth_threshold)
 
     def select_blink_type(self, event):
         self.context.blink_type = self.context.blink_types[event.GetSelection()]


### PR DESCRIPTION
- 口パクの差分画像のためのしきい値に対する倍率を設定できる実装を追加
    - MP3ファイルにおいて、口パクが小さくなる現象を確認したため、この設定を制御可能とした
    - しきい値の倍率を下げることで、口パクを大きくすることができる
- 設定追加に伴い、プロジェクトファイルのバージョンを0.2に変更した